### PR TITLE
fix: training completion no longer sticks on Redis/WS failure

### DIFF
--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -124,6 +124,15 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
     return () => clearInterval(id);
   }, []);
 
+  // Poll training queue every 10 s so completions show even if the WS event
+  // was missed (e.g. timer service restarted mid-training)
+  useEffect(() => {
+    const id = setInterval(() => {
+      getTraining().then(t => setTraining(t.training)).catch(() => null);
+    }, 10_000);
+    return () => clearInterval(id);
+  }, []);
+
   // WebSocket connection
   useEffect(() => {
     const ws = openWs((msg) => {

--- a/src/services/timer-service.ts
+++ b/src/services/timer-service.ts
@@ -472,19 +472,30 @@ export async function processDueTrainings(now: number): Promise<void> {
 }
 
 async function handleTrainingComplete(entry: TrainQueueEntry): Promise<void> {
+  // DB update is always first and isolated — a Redis failure must never leave
+  // the unit stuck in TRAINING status.
   await prisma.unit.update({
     where: { id: entry.unitId },
     data:  { status: "IDLE", trainingEndsAt: null },
   });
 
-  const cpCost = UNIT_STATS[entry.unitType as UnitType]?.commandPointsCost ?? 0;
-  if (cpCost > 0) {
-    await adjustCommandPoints(entry.playerId, cpCost * entry.quantity);
+  // CP and pub/sub are best-effort — log failures but don't re-throw
+  try {
+    const cpCost = UNIT_STATS[entry.unitType as UnitType]?.commandPointsCost ?? 0;
+    if (cpCost > 0) {
+      await adjustCommandPoints(entry.playerId, cpCost * entry.quantity);
+    }
+  } catch (err) {
+    console.error(`[timer] adjustCommandPoints failed for unit ${entry.unitId}:`, err);
   }
 
-  await publishPlayerEvent(entry.playerId, "UNIT_TRAINED", {
-    unitType: entry.unitType,
-    quantity: entry.quantity,
-    message:  `${entry.quantity}× ${UNIT_STATS[entry.unitType as UnitType]?.displayName ?? entry.unitType} training complete`,
-  });
+  try {
+    await publishPlayerEvent(entry.playerId, "UNIT_TRAINED", {
+      unitType: entry.unitType,
+      quantity: entry.quantity,
+      message:  `${entry.quantity}× ${UNIT_STATS[entry.unitType as UnitType]?.displayName ?? entry.unitType} training complete`,
+    });
+  } catch (err) {
+    console.error(`[timer] publishPlayerEvent failed for unit ${entry.unitId}:`, err);
+  }
 }


### PR DESCRIPTION
Isolate the DB status update in handleTrainingComplete so a Redis error (adjustCommandPoints or publishPlayerEvent) can never leave a unit stuck in TRAINING. Also add a 10s polling interval on the training queue in the dashboard so the UI self-heals even when the UNIT_TRAINED WS event is missed.