### PR TITLE
feat: add PixiJS hex grid world map as primary game view

### DIFF
--- a/src/client/package-lock.json
+++ b/src/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "global-mandate-client",
       "version": "1.0.0",
       "dependencies": {
+        "pixi.js": "^8.17.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -301,43 +302,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -416,6 +380,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.12",
@@ -735,6 +705,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -782,6 +758,21 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
+      "integrity": "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
+      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -894,6 +885,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.329",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
@@ -910,6 +907,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -953,6 +956,27 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -1302,6 +1326,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1320,6 +1350,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.17.1.tgz",
+      "integrity": "sha512-OB4TpZHrP5RYy+7FqmFrAc0IHRhfOoNIfF4sVeinvK3aG1r2pYrSMneJAKi9+WvGKC70Dj7GEpZ2OZGB6o/xdg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.11",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.1.2",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/postcss": {
@@ -1454,6 +1510,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tinyglobby": {

--- a/src/client/package.json
+++ b/src/client/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "pixi.js": "^8.17.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/src/client/src/App.tsx
+++ b/src/client/src/App.tsx
@@ -1,10 +1,19 @@
-import { useState, useEffect, useCallback } from "react";
-import { register, login, logout, isLoggedIn, getPlayerStatus, getBase, upgradeBuilding, constructBuilding, getTraining, trainUnit, openWs, TOKEN_KEY } from "./api.js";
-import type { Building, PlayerStatus, FOB, WsMessage, TrainingUnit } from "./types.js";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import {
+  register, login, logout, isLoggedIn,
+  getPlayerStatus, getBase, upgradeBuilding, constructBuilding,
+  getTraining, trainUnit, openWs,
+  getMapSectors, getScoutReports,
+  TOKEN_KEY,
+} from "./api.js";
+import type { Building, PlayerStatus, FOB, WsMessage, TrainingUnit, Zone, ScoutReport } from "./types.js";
+import { resolveZoneVisibility } from "./lib/mapVisibility.js";
 import { StatusHeader }   from "./components/StatusHeader.js";
 import { BuildingList }   from "./components/BuildingList.js";
 import { BuildingDetail } from "./components/BuildingDetail.js";
 import { AlertFeed }      from "./components/AlertFeed.js";
+import { HexMap }         from "./components/HexMap.js";
+import { ZonePanel }      from "./components/ZonePanel.js";
 
 // ─── Login screen ──────────────────────────────────────────────
 
@@ -46,7 +55,7 @@ function LoginForm({ onLogin }: { onLogin: () => void }) {
       padding: "32px 40px", width: 320,
     },
     title: { color: "#e8e8e8", fontSize: 18, textTransform: "uppercase", letterSpacing: 3, marginBottom: 24 },
-    tabs: { display: "flex", marginBottom: 24, borderBottom: "1px solid #2a2a2a" },
+    tabs:  { display: "flex", marginBottom: 24, borderBottom: "1px solid #2a2a2a" },
     tab: {
       flex: 1, background: "none", border: "none", padding: "8px", fontSize: 11,
       letterSpacing: 1, textTransform: "uppercase", cursor: "pointer", fontFamily: "inherit",
@@ -105,24 +114,52 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
   const [alerts,           setAlerts]           = useState<WsMessage[]>([]);
   const [error,            setError]            = useState<string | null>(null);
   const [selectedBuilding, setSelectedBuilding] = useState<Building | null>(null);
+  // Map state
+  const [zones,            setZones]            = useState<Zone[]>([]);
+  const [selectedZone,     setSelectedZone]     = useState<Zone | null>(null);
+  const [showBuildingPanel, setShowBuildingPanel] = useState(false);
+
+  // Stable refs for WS callback closures
+  const playerRef       = useRef<PlayerStatus | null>(null);
+  const scoutReportsRef = useRef<ScoutReport[]>([]);
+  useEffect(() => { playerRef.current = player; }, [player]);
 
   const addAlert = useCallback((msg: WsMessage) => {
     setAlerts(prev => [...prev.slice(-(MAX_ALERTS - 1)), msg]);
   }, []);
 
+  // ── Rebuild zone visibility whenever zones or player changes ──
+  const rawZonesRef = useRef<Omit<Zone, "visibility" | "units">[]>([]);
+
+  function rebuildZones(p: PlayerStatus) {
+    const resolved = resolveZoneVisibility(rawZonesRef.current, p.id, scoutReportsRef.current);
+    setZones(resolved);
+  }
+
   // Initial data load
   useEffect(() => {
-    Promise.all([getPlayerStatus(), getBase(), getTraining()])
-      .then(([p, b, t]) => { setPlayer(p); setFob(b.fob); setTraining(t.training); })
+    Promise.all([getPlayerStatus(), getBase(), getTraining(), getMapSectors(), getScoutReports()])
+      .then(([p, b, t, m, s]) => {
+        setPlayer(p);
+        setFob(b.fob);
+        setTraining(t.training);
+        scoutReportsRef.current = s.reports;
+        rawZonesRef.current = m.sectors.flatMap(sec =>
+          sec.zones.map(z => ({ ...z, sectorId: sec.id }))
+        );
+        rebuildZones(p);
+      })
       .catch(err => setError(err instanceof Error ? err.message : "Failed to load"));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Refresh player status every 30 s
   useEffect(() => {
     const id = setInterval(() => {
-      getPlayerStatus().then(setPlayer).catch(() => null);
+      getPlayerStatus().then(p => { setPlayer(p); rebuildZones(p); }).catch(() => null);
     }, 30_000);
     return () => clearInterval(id);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Poll training queue every 10 s
@@ -133,79 +170,115 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
     return () => clearInterval(id);
   }, []);
 
-  // WebSocket connection
+  // WebSocket
   useEffect(() => {
     const ws = openWs((msg) => {
       addAlert(msg);
-      if (["ZONE_CAPTURED", "BATTLE_RESOLVED", "UNIT_ARRIVED"].includes(msg.type)) {
-        getPlayerStatus().then(setPlayer).catch(() => null);
-      }
+
       if (msg.type === "BUILDING_UPGRADE_COMPLETED" || msg.type === "BUILDING_CONSTRUCTION_COMPLETED") {
         Promise.all([getPlayerStatus(), getBase()])
           .then(([p, b]) => {
             setPlayer(p);
             setFob(b.fob);
-            // Keep selectedBuilding in sync with the refreshed FOB data
             setSelectedBuilding(prev =>
               prev ? (b.fob.buildings.find(bl => bl.id === prev.id) ?? prev) : null,
             );
           })
           .catch(() => null);
       }
+
       if (msg.type === "UNIT_TRAINING_STARTED" || msg.type === "UNIT_TRAINED") {
         Promise.all([getPlayerStatus(), getTraining()])
           .then(([p, t]) => { setPlayer(p); setTraining(t.training); })
           .catch(() => null);
       }
+
+      // Refresh map on zone-affecting events
+      if (["ZONE_CAPTURED", "BATTLE_RESOLVED", "UNIT_ARRIVED"].includes(msg.type)) {
+        Promise.all([getPlayerStatus(), getMapSectors()])
+          .then(([p, m]) => {
+            setPlayer(p);
+            rawZonesRef.current = m.sectors.flatMap(sec =>
+              sec.zones.map(z => ({ ...z, sectorId: sec.id }))
+            );
+            rebuildZones(p);
+          })
+          .catch(() => null);
+      }
     });
     return () => ws.close();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addAlert]);
 
+  // ── Zone click handler ─────────────────────────────────────────
+  function handleZoneClick(zone: Zone) {
+    setSelectedZone(zone);
+    if (fob && zone.id === fob.zoneId) {
+      setShowBuildingPanel(true);
+    } else {
+      setShowBuildingPanel(false);
+      setSelectedBuilding(null);
+    }
+  }
+
+  // ── Styles ─────────────────────────────────────────────────────
   const S: Record<string, React.CSSProperties> = {
-    shell:   { display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" },
+    shell:    { display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" },
     topbar: {
       display: "flex", justifyContent: "flex-end",
       padding: "6px 20px", borderBottom: "1px solid #1a1a1a",
-      background: "#0d0d0d",
+      background: "#0d0d0d", flexShrink: 0,
     },
     logoutBtn: {
       background: "none", border: "none", color: "#444", cursor: "pointer",
       fontSize: 11, fontFamily: "inherit", letterSpacing: 1, textTransform: "uppercase",
     },
-    // Row splits the main area into list + detail panes
-    contentRow: { flex: 1, display: "flex", overflow: "hidden" },
-    // Left pane: narrow when a building is selected, full-width otherwise
-    leftPane: {
-      display: "flex", flexDirection: "column", overflow: "hidden",
-      transition: "width 0.2s ease",
-      width: selectedBuilding ? 180 : "100%",
-      minWidth: selectedBuilding ? 180 : undefined,
-      maxWidth: selectedBuilding ? 180 : undefined,
-      borderRight: selectedBuilding ? "1px solid #1a1a1a" : "none",
-      flexShrink: 0,
+    mapWrapper: { position: "relative", flex: 1, overflow: "hidden" },
+    // FOB building panel — right overlay
+    buildingPanel: {
+      position: "absolute", top: 0, right: 0, bottom: 0,
+      display: "flex", width: 460,
+      background: "#0d0d0d", borderLeft: "1px solid #1a1a1a",
+      zIndex: 20,
     },
-    leftScroll:  { overflowY: "auto", flex: 1 },
-    // Right pane: building detail + alert feed
-    rightPane:   { flex: 1, display: "flex", flexDirection: "column", overflow: "hidden" },
-    rightScroll: { flex: 1, overflowY: "auto" },
-    divider:     { borderTop: "1px solid #1a1a1a" },
-    error:       { padding: "12px 20px", color: "#f44336", fontSize: 12 },
+    buildingListCol:   { width: 180, overflowY: "auto", borderRight: "1px solid #111" },
+    buildingDetailCol: { flex: 1, overflowY: "auto" },
+    // Alert feed — top-right corner overlay
+    alertOverlay: {
+      position: "absolute", top: 8, width: 300,
+      maxHeight: 200, overflowY: "auto", zIndex: 5,
+      background: "rgba(10,10,10,0.85)", borderRadius: 2,
+    },
+    error: { padding: "12px 20px", color: "#f44336", fontSize: 12 },
   };
 
   if (error) return <div style={S.error}>⚠ {error}</div>;
+
+  const alertRight = showBuildingPanel ? 468 : 8;
 
   return (
     <div style={S.shell}>
       <div style={S.topbar}>
         <button style={S.logoutBtn} onClick={onLogout}>Disconnect</button>
       </div>
+
       {player && <StatusHeader player={player} />}
 
-      <div style={S.contentRow}>
-        {/* Left pane — building list (grid or collapsed) */}
-        <div style={S.leftPane}>
-          <div style={S.leftScroll}>
-            {fob && player && (
+      <div style={S.mapWrapper}>
+        {/* Hex map fills the full area */}
+        {player && (
+          <HexMap
+            zones={zones}
+            playerId={player.id}
+            fobZoneId={fob?.zoneId ?? null}
+            onZoneClick={handleZoneClick}
+          />
+        )}
+
+        {/* FOB building panel — slides in from right when FOB zone selected */}
+        {showBuildingPanel && fob && player && (
+          <div style={S.buildingPanel}>
+            <div style={S.buildingListCol}>
               <BuildingList
                 buildings={fob.buildings}
                 steel={player.steel}
@@ -219,55 +292,51 @@ function Dashboard({ onLogout }: { onLogout: () => void }) {
                   setPlayer(updated);
                 }}
               />
-            )}
-          </div>
-        </div>
-
-        {/* Right pane — building detail or alert feed */}
-        <div style={S.rightPane}>
-          <div style={S.rightScroll}>
-            {selectedBuilding && player ? (
-              <BuildingDetail
-                building={selectedBuilding}
-                steel={player.steel}
-                credits={player.credits}
-                fuel={player.fuel}
-                rations={player.rations}
-                training={training}
-                onUpgrade={async (buildingType) => {
-                  const { building } = await upgradeBuilding(buildingType);
-                  setFob(prev => prev && {
-                    ...prev,
-                    buildings: prev.buildings.map(b => b.id === building.id ? building : b),
-                  });
-                  setSelectedBuilding(building);
-                  const updated = await getPlayerStatus();
-                  setPlayer(updated);
-                }}
-                onTrain={async (unitType, quantity) => {
-                  await trainUnit(unitType, quantity);
-                  const [p, t] = await Promise.all([getPlayerStatus(), getTraining()]);
-                  setPlayer(p);
-                  setTraining(t.training);
-                }}
-                onBack={() => setSelectedBuilding(null)}
-              />
-            ) : (
-              <>
-                <div style={S.divider} />
-                <AlertFeed alerts={alerts} />
-              </>
-            )}
-          </div>
-          {/* Alert feed always visible below detail when a building is open */}
-          {selectedBuilding && (
-            <>
-              <div style={S.divider} />
-              <div style={{ maxHeight: 200, overflowY: "auto" }}>
-                <AlertFeed alerts={alerts} />
+            </div>
+            {selectedBuilding && (
+              <div style={S.buildingDetailCol}>
+                <BuildingDetail
+                  building={selectedBuilding}
+                  steel={player.steel}
+                  credits={player.credits}
+                  fuel={player.fuel}
+                  rations={player.rations}
+                  training={training}
+                  onUpgrade={async (buildingType) => {
+                    const { building } = await upgradeBuilding(buildingType);
+                    setFob(prev => prev && {
+                      ...prev,
+                      buildings: prev.buildings.map(b => b.id === building.id ? building : b),
+                    });
+                    setSelectedBuilding(building);
+                    const updated = await getPlayerStatus();
+                    setPlayer(updated);
+                  }}
+                  onTrain={async (unitType, quantity) => {
+                    await trainUnit(unitType, quantity);
+                    const [p, t] = await Promise.all([getPlayerStatus(), getTraining()]);
+                    setPlayer(p);
+                    setTraining(t.training);
+                  }}
+                  onBack={() => setSelectedBuilding(null)}
+                />
               </div>
-            </>
-          )}
+            )}
+          </div>
+        )}
+
+        {/* Zone detail panel — slides up from bottom */}
+        {player && (
+          <ZonePanel
+            zone={selectedZone}
+            playerId={player.id}
+            onClose={() => setSelectedZone(null)}
+          />
+        )}
+
+        {/* Alert feed — top-right corner overlay */}
+        <div style={{ ...S.alertOverlay, right: alertRight }}>
+          <AlertFeed alerts={alerts} />
         </div>
       </div>
     </div>

--- a/src/client/src/api.ts
+++ b/src/client/src/api.ts
@@ -1,6 +1,6 @@
 // Typed API helpers — all routes prefixed /api/v1
 
-import type { PlayerStatus, FOB } from "./types.js";
+import type { PlayerStatus, FOB, Sector, Zone, ZoneUnit, ScoutReport } from "./types.js";
 
 export const TOKEN_KEY = "gm_token";
 
@@ -81,6 +81,20 @@ export async function trainUnit(unitType: string, quantity: number): Promise<{ u
     method: "POST",
     body:   JSON.stringify({ unitType, quantity }),
   });
+}
+
+// ─── Map ───────────────────────────────────────────────────────
+
+export async function getMapSectors(): Promise<{ sectors: Sector[] }> {
+  return apiFetch<{ sectors: Sector[] }>("/map/sectors");
+}
+
+export async function getZoneDetail(zoneId: string): Promise<{ zone: Zone & { units: ZoneUnit[] } }> {
+  return apiFetch<{ zone: Zone & { units: ZoneUnit[] } }>(`/map/zone/${encodeURIComponent(zoneId)}`);
+}
+
+export async function getScoutReports(): Promise<{ reports: ScoutReport[] }> {
+  return apiFetch<{ reports: ScoutReport[] }>("/map/scout-reports");
 }
 
 // ─── WebSocket ─────────────────────────────────────────────────

--- a/src/client/src/components/HexMap.tsx
+++ b/src/client/src/components/HexMap.tsx
@@ -1,0 +1,281 @@
+// =============================================================
+// Global Mandate — PixiJS Hex Map
+// Renders 700 axial hex zones with pan/zoom and click detection.
+// =============================================================
+
+import { useEffect, useRef } from "react";
+import { Application, Container, Graphics, Text, TextStyle, Point } from "pixi.js";
+import type { Zone, ZoneVisibility } from "../types.js";
+
+// ─── Hex geometry (pointy-top) ────────────────────────────────
+
+const HEX_SIZE = 24;
+
+function axialToPixel(q: number, r: number): { x: number; y: number } {
+  return {
+    x: HEX_SIZE * (Math.sqrt(3) * q + (Math.sqrt(3) / 2) * r),
+    y: HEX_SIZE * (3 / 2) * r,
+  };
+}
+
+function hexCornerPoints(cx: number, cy: number): number[] {
+  const pts: number[] = [];
+  for (let i = 0; i < 6; i++) {
+    const angle = (Math.PI / 180) * (60 * i - 30);
+    pts.push(cx + HEX_SIZE * Math.cos(angle), cy + HEX_SIZE * Math.sin(angle));
+  }
+  return pts;
+}
+
+// ─── Color palette ────────────────────────────────────────────
+
+const COLORS = {
+  owned:    { fill: 0x1a3a1a, border: 0x2a5a2a },
+  scouted:  { fill: 0x1a1a2a, border: 0x2a2a4a },
+  enemy:    { fill: 0x2a1a1a, border: 0x3a1e1e },
+  dark:     { fill: 0x0e0e0e, border: 0x1a1a1a },
+  fobRing:  0x4caf50,
+  selected: 0xfdd835,
+} as const;
+
+function hexColors(zone: Zone): { fill: number; border: number } {
+  if (zone.visibility === "owned")   return COLORS.owned;
+  if (zone.visibility === "scouted") return COLORS.scouted;
+  // dark — but we may know there's an enemy owner
+  if (zone.ownerPlayerId !== null)   return COLORS.enemy;
+  return COLORS.dark;
+}
+
+// ─── Props ────────────────────────────────────────────────────
+
+interface HexMapProps {
+  zones:       Zone[];
+  playerId:    string;
+  fobZoneId:   string | null;
+  onZoneClick: (zone: Zone) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────
+
+export function HexMap({ zones, playerId, fobZoneId, onZoneClick }: HexMapProps) {
+  const containerRef    = useRef<HTMLDivElement>(null);
+  const appRef          = useRef<Application | null>(null);
+  const worldRef        = useRef<Container | null>(null);
+  // Per-zone Graphics objects for O(1) updates
+  const hexGfxRef       = useRef<Map<string, Graphics>>(new Map());
+  // Stable refs so PixiJS callbacks don't capture stale closures
+  const zonesRef        = useRef<Zone[]>(zones);
+  const onZoneClickRef  = useRef(onZoneClick);
+  const fobZoneIdRef    = useRef(fobZoneId);
+  const selectedIdRef   = useRef<string | null>(null);
+  const isDraggingRef   = useRef(false);
+
+  // Keep refs in sync with props
+  useEffect(() => { zonesRef.current = zones; }, [zones]);
+  useEffect(() => { onZoneClickRef.current = onZoneClick; }, [onZoneClick]);
+  useEffect(() => { fobZoneIdRef.current = fobZoneId; }, [fobZoneId]);
+
+  // ── Initial PixiJS setup ─────────────────────────────────────
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    let destroyed = false;
+
+    const app = new Application();
+    appRef.current = app;
+
+    void app.init({
+      resizeTo:        el,
+      backgroundColor: 0x0a0a0a,
+      antialias:       false,
+      resolution:      window.devicePixelRatio || 1,
+      autoDensity:     true,
+    }).then(() => {
+      if (destroyed) { app.destroy(true); return; }
+      el.appendChild(app.canvas);
+      buildScene(app);
+    });
+
+    return () => {
+      destroyed = true;
+      hexGfxRef.current.clear();
+      worldRef.current = null;
+      appRef.current   = null;
+      app.destroy(true, { children: true });
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // runs once
+
+  // ── Recolor hexes when zone data changes ─────────────────────
+  useEffect(() => {
+    const gfxMap = hexGfxRef.current;
+    if (gfxMap.size === 0) return; // scene not built yet
+    for (const zone of zones) {
+      const gfx = gfxMap.get(zone.id);
+      if (gfx) redrawHex(gfx, zone, zone.id === selectedIdRef.current, zone.id === fobZoneIdRef.current);
+    }
+  }, [zones]);
+
+  // ─ FOB ring update when fobZoneId changes ───────────────────
+  useEffect(() => {
+    const gfxMap = hexGfxRef.current;
+    if (gfxMap.size === 0) return;
+    // Redraw all zones to refresh FOB ring
+    for (const zone of zonesRef.current) {
+      const gfx = gfxMap.get(zone.id);
+      if (gfx) redrawHex(gfx, zone, zone.id === selectedIdRef.current, zone.id === fobZoneId);
+    }
+  }, [fobZoneId]);
+
+  // ─── Build the initial PixiJS scene ─────────────────────────
+
+  function buildScene(app: Application) {
+    const world = new Container();
+    worldRef.current = world;
+    app.stage.addChild(world);
+
+    // Center view on FOB zone if known, otherwise on world midpoint (q=40, r=40)
+    const fobZone = zonesRef.current.find(z => z.id === fobZoneIdRef.current);
+    const focusQ  = fobZone ? fobZone.q : 40;
+    const focusR  = fobZone ? fobZone.r : 40;
+    const focus   = axialToPixel(focusQ, focusR);
+    world.position.set(
+      app.screen.width  / 2 - focus.x,
+      app.screen.height / 2 - focus.y,
+    );
+
+    // Draw all hexes
+    for (const zone of zonesRef.current) {
+      const gfx = createHex(zone);
+      world.addChild(gfx);
+      hexGfxRef.current.set(zone.id, gfx);
+    }
+
+    setupInteractivity(app, world);
+  }
+
+  // ─── Draw / redraw a single hex Graphics ────────────────────
+
+  function createHex(zone: Zone): Graphics {
+    const gfx = new Graphics();
+    gfx.label = zone.id;
+    redrawHex(gfx, zone, false, zone.id === fobZoneIdRef.current);
+    gfx.interactive = true;
+    gfx.cursor      = "pointer";
+    return gfx;
+  }
+
+  function redrawHex(gfx: Graphics, zone: Zone, selected: boolean, isFob: boolean) {
+    const { x, y } = axialToPixel(zone.q, zone.r);
+    const { fill, border } = hexColors(zone);
+    const borderColor = selected ? COLORS.selected : isFob ? COLORS.fobRing : border;
+    const borderWidth = selected || isFob ? 1.5 : 0.5;
+
+    gfx.clear();
+    gfx.poly(hexCornerPoints(x, y)).fill(fill).stroke({ color: borderColor, width: borderWidth });
+
+    // Zone name label for visible zones
+    if (zone.visibility !== "dark") {
+      const label = new Text({
+        text:  zone.name.length > 12 ? zone.name.slice(0, 12) : zone.name,
+        style: new TextStyle({ fontSize: 6, fill: 0x888888, fontFamily: "monospace" }),
+      });
+      label.anchor.set(0.5);
+      label.position.set(x, y + HEX_SIZE * 0.52);
+      label.visible = true; // hidden below zoom 0.6 via world scale check in app.ticker
+      gfx.addChild(label);
+    }
+
+    // FOB indicator dot
+    if (isFob) {
+      const dot = new Graphics();
+      dot.circle(x, y - 4, 3).fill(COLORS.fobRing);
+      gfx.addChild(dot);
+    }
+  }
+
+  // ─── Pan + zoom interactivity ────────────────────────────────
+
+  function setupInteractivity(app: Application, world: Container) {
+    let dragStartScreen = { x: 0, y: 0 };
+    let dragStartWorld  = { x: 0, y: 0 };
+    let pointerDownPos  = { x: 0, y: 0 };
+
+    app.stage.interactive = true;
+    app.stage.hitArea     = app.screen;
+
+    app.stage.on("pointerdown", (e) => {
+      isDraggingRef.current = false;
+      dragStartScreen = { x: e.global.x, y: e.global.y };
+      dragStartWorld  = { x: world.x, y: world.y };
+      pointerDownPos  = { x: e.global.x, y: e.global.y };
+    });
+
+    app.stage.on("pointermove", (e) => {
+      const dx = e.global.x - dragStartScreen.x;
+      const dy = e.global.y - dragStartScreen.y;
+      if (!isDraggingRef.current && Math.sqrt(dx * dx + dy * dy) > 5) {
+        isDraggingRef.current = true;
+      }
+      if (isDraggingRef.current) {
+        world.x = dragStartWorld.x + dx;
+        world.y = dragStartWorld.y + dy;
+      }
+    });
+
+    app.stage.on("pointerup", () => { isDraggingRef.current = false; });
+    app.stage.on("pointerupoutside", () => { isDraggingRef.current = false; });
+
+    // Wire click on each hex via pointerup — fires only if not dragging
+    for (const [zoneId, gfx] of hexGfxRef.current) {
+      const zone = zonesRef.current.find(z => z.id === zoneId);
+      if (!zone) continue;
+      gfx.on("pointerup", (e) => {
+        e.stopPropagation();
+        if (isDraggingRef.current) return;
+
+        // Deselect previous hex
+        if (selectedIdRef.current) {
+          const prevGfx  = hexGfxRef.current.get(selectedIdRef.current);
+          const prevZone = zonesRef.current.find(z => z.id === selectedIdRef.current);
+          if (prevGfx && prevZone) {
+            redrawHex(prevGfx, prevZone, false, prevZone.id === fobZoneIdRef.current);
+          }
+        }
+
+        // Select this hex
+        selectedIdRef.current = zone.id;
+        redrawHex(gfx, zone, true, zone.id === fobZoneIdRef.current);
+        onZoneClickRef.current(zone);
+      });
+    }
+
+    // Zoom toward cursor on scroll
+    app.canvas.addEventListener("wheel", (e) => {
+      e.preventDefault();
+      const factor   = e.deltaY < 0 ? 1.1 : 1 / 1.1;
+      const newScale = Math.max(0.25, Math.min(5.0, world.scale.x * factor));
+
+      const worldPos    = world.toLocal(new Point(e.offsetX, e.offsetY));
+      world.scale.set(newScale);
+      const newScreenPos = world.toGlobal(worldPos);
+      world.x += e.offsetX - newScreenPos.x;
+      world.y += e.offsetY - newScreenPos.y;
+
+      // Toggle zone labels based on zoom level
+      const showLabels = newScale >= 0.6;
+      for (const gfx of hexGfxRef.current.values()) {
+        for (const child of gfx.children) {
+          if (child instanceof Text) child.visible = showLabels;
+        }
+      }
+    }, { passive: false });
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      style={{ width: "100%", height: "100%", overflow: "hidden", background: "#0a0a0a" }}
+    />
+  );
+}

--- a/src/client/src/components/ZonePanel.tsx
+++ b/src/client/src/components/ZonePanel.tsx
@@ -1,0 +1,172 @@
+// =============================================================
+// Global Mandate — Zone Detail Panel
+// Slides up from the bottom when a zone is selected on the map.
+// =============================================================
+
+import { useEffect, useState } from "react";
+import { getZoneDetail }        from "../api.js";
+import type { Zone, ZoneUnit }  from "../types.js";
+
+interface Props {
+  zone:     Zone | null;
+  playerId: string;
+  onClose:  () => void;
+}
+
+const UNIT_LABELS: Record<string, string> = {
+  INFANTRY_GRUNT:    "Infantry",
+  SPECIAL_FORCES:    "Special Forces",
+  RANGERS:           "Rangers",
+  MARSOC_ATGM:       "MARSOC ATGM",
+  LIGHT_VEHICLE:     "Light Vehicle",
+  MAIN_BATTLE_TANK:  "Main Battle Tank",
+  HEAVY_ASSAULT:     "Heavy Assault",
+  LIGHT_TANK:        "Light Tank",
+  ATTACK_HELICOPTER: "Attack Helicopter",
+  TRANSPORT_HELICOPTER: "Transport Helicopter",
+};
+
+const S: Record<string, React.CSSProperties> = {
+  panel: {
+    position:   "absolute",
+    bottom:     0,
+    left:       0,
+    right:      0,
+    maxHeight:  "38vh",
+    background: "#0f0f0f",
+    borderTop:  "1px solid #222",
+    zIndex:     10,
+    overflowY:  "auto",
+    transition: "transform 0.22s ease",
+  },
+  inner:     { padding: "14px 20px 18px" },
+  header:    { display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10 },
+  name:      { color: "#e8e8e8", fontSize: 15, fontWeight: "bold" },
+  owner:     { color: "#555", fontSize: 11, marginTop: 2 },
+  closeBtn: {
+    background: "none", border: "none", color: "#444", cursor: "pointer",
+    fontSize: 18, fontFamily: "inherit", lineHeight: 1, padding: "0 2px",
+  },
+  sectionHead: { color: "#555", fontSize: 10, textTransform: "uppercase", letterSpacing: 2, marginBottom: 6, marginTop: 12 },
+  grid:        { display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 8 },
+  chip: {
+    background: "#141414", border: "1px solid #222", borderRadius: 2,
+    padding: "6px 10px", display: "flex", flexDirection: "column", gap: 2,
+  },
+  chipLabel: { color: "#555", fontSize: 9, textTransform: "uppercase", letterSpacing: 1 },
+  chipValue: { color: "#c8c8c8", fontSize: 13 },
+  unitRow:   { display: "flex", justifyContent: "space-between", padding: "4px 0", borderBottom: "1px solid #141414" },
+  unitName:  { color: "#888", fontSize: 12 },
+  unitQty:   { color: "#c8c8c8", fontSize: 12 },
+  tagRow:    { display: "flex", gap: 8, flexWrap: "wrap" as const, marginTop: 4 },
+  tag: {
+    background: "#141414", border: "1px solid #1e1e1e", borderRadius: 2,
+    padding: "2px 8px", fontSize: 10, color: "#666",
+  },
+  tagGreen:  { border: "1px solid #1a3a1a", color: "#4caf50" },
+  tagOrange: { border: "1px solid #3a2a00", color: "#f57c00" },
+  tagRed:    { border: "1px solid #3a1a1a", color: "#f44336" },
+};
+
+export function ZonePanel({ zone, playerId, onClose }: Props) {
+  const [liveUnits, setLiveUnits] = useState<ZoneUnit[] | null>(null);
+  const [loading,   setLoading]   = useState(false);
+
+  // Fetch live units when zone changes
+  useEffect(() => {
+    if (!zone || zone.visibility === "dark") {
+      setLiveUnits(null);
+      return;
+    }
+    setLiveUnits(null);
+    setLoading(true);
+    getZoneDetail(zone.id)
+      .then(data => setLiveUnits(data.zone.units ?? []))
+      .catch(() => setLiveUnits([]))
+      .finally(() => setLoading(false));
+  }, [zone?.id]);
+
+  const visible     = zone !== null;
+  const units       = liveUnits ?? zone?.units ?? [];
+  const canSeeInfo  = zone && zone.visibility !== "dark";
+  const isOwned     = zone?.visibility === "owned";
+  const ownerLabel  = zone?.ownerPlayerId
+    ? (zone.ownerPlayerId === playerId ? "You" : "Enemy")
+    : "Unoccupied";
+
+  return (
+    <div style={{ ...S.panel, transform: visible ? "translateY(0)" : "translateY(100%)" }}>
+      {zone && (
+        <div style={S.inner}>
+          {/* Header */}
+          <div style={S.header}>
+            <div>
+              <div style={S.name}>{zone.name}</div>
+              <div style={S.owner}>
+                {ownerLabel}
+                {zone.capturedAt && isOwned && (
+                  <span style={{ marginLeft: 8, color: "#333" }}>
+                    Captured {new Date(zone.capturedAt).toLocaleDateString()}
+                  </span>
+                )}
+              </div>
+            </div>
+            <button style={S.closeBtn} onClick={onClose}>×</button>
+          </div>
+
+          {/* Resource yields */}
+          {canSeeInfo && (zone.fuelPerHour !== null || zone.rationsPerHour !== null || zone.steelPerHour !== null || zone.creditsPerHour !== null) && (
+            <>
+              <div style={S.sectionHead}>Resource Yields</div>
+              <div style={S.grid}>
+                {zone.fuelPerHour    !== null && <div style={S.chip}><span style={S.chipLabel}>Fuel</span><span style={S.chipValue}>+{zone.fuelPerHour}/hr</span></div>}
+                {zone.rationsPerHour !== null && <div style={S.chip}><span style={S.chipLabel}>Rations</span><span style={S.chipValue}>+{zone.rationsPerHour}/hr</span></div>}
+                {zone.steelPerHour   !== null && <div style={S.chip}><span style={S.chipLabel}>Steel</span><span style={S.chipValue}>+{zone.steelPerHour}/hr</span></div>}
+                {zone.creditsPerHour !== null && <div style={S.chip}><span style={S.chipLabel}>Credits</span><span style={S.chipValue}>+{zone.creditsPerHour}/hr</span></div>}
+              </div>
+            </>
+          )}
+
+          {/* Units */}
+          {canSeeInfo && (
+            <>
+              <div style={S.sectionHead}>Units Present</div>
+              {loading && <div style={{ color: "#444", fontSize: 12 }}>Loading...</div>}
+              {!loading && units.length === 0 && <div style={{ color: "#333", fontSize: 12 }}>No units</div>}
+              {!loading && units.map(u => (
+                <div key={u.id} style={S.unitRow}>
+                  <span style={S.unitName}>{UNIT_LABELS[u.unitType] ?? u.unitType}</span>
+                  <span style={S.unitQty}>
+                    ×{u.quantity}
+                    {u.healthPct !== null && u.healthPct < 100 && (
+                      <span style={{ color: "#f57c00", marginLeft: 6 }}>{u.healthPct}%</span>
+                    )}
+                  </span>
+                </div>
+              ))}
+            </>
+          )}
+
+          {/* Zone properties (owned only) */}
+          {isOwned && (
+            <>
+              <div style={S.sectionHead}>Zone Status</div>
+              <div style={S.tagRow}>
+                <span style={{ ...S.tag, ...(zone.isConnected ? S.tagGreen : S.tagRed) }}>
+                  {zone.isConnected ? "● Signal Connected" : "● Signal Lost"}
+                </span>
+                {zone.fortificationLevel > 0 && (
+                  <span style={{ ...S.tag, ...S.tagOrange }}>
+                    ⚑ Fort {zone.fortificationLevel}
+                  </span>
+                )}
+                {zone.hasRoad && <span style={S.tag}>🛣 Road</span>}
+                {zone.bridgeDestroyed && <span style={{ ...S.tag, ...S.tagRed }}>✕ Bridge Destroyed</span>}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/client/src/lib/mapVisibility.ts
+++ b/src/client/src/lib/mapVisibility.ts
@@ -1,0 +1,47 @@
+import type { Zone, ZoneVisibility, ScoutReport } from "../types.js";
+
+type RawZone = Omit<Zone, "visibility" | "units">;
+
+/**
+ * Resolves fog-of-war visibility for every zone.
+ *
+ * Rules:
+ *   "owned"   — zone belongs to the current player (full info)
+ *   "scouted" — a valid (non-expired) ScoutReport exists for this zone
+ *   "dark"    — everything else (only owner identity visible if known)
+ */
+export function resolveZoneVisibility(
+  rawZones:     RawZone[],
+  playerId:     string,
+  scoutReports: ScoutReport[],
+): Zone[] {
+  const now = Date.now();
+
+  // Build lookup: zoneId → most recent valid scout report
+  const scoutMap = new Map<string, ScoutReport>();
+  for (const report of scoutReports) {
+    if (new Date(report.expiresAt).getTime() > now) {
+      const existing = scoutMap.get(report.targetZoneId);
+      if (!existing || report.reportedAt > existing.reportedAt) {
+        scoutMap.set(report.targetZoneId, report);
+      }
+    }
+  }
+
+  return rawZones.map((zone): Zone => {
+    if (zone.ownerPlayerId === playerId) {
+      return { ...zone, visibility: "owned" as ZoneVisibility };
+    }
+
+    const report = scoutMap.get(zone.id);
+    if (report) {
+      return {
+        ...zone,
+        visibility: "scouted" as ZoneVisibility,
+        units:      report.unitSnapshot,
+      };
+    }
+
+    return { ...zone, visibility: "dark" as ZoneVisibility };
+  });
+}

--- a/src/client/src/types.ts
+++ b/src/client/src/types.ts
@@ -48,3 +48,53 @@ export interface WsMessage {
   payload: Record<string, unknown>;
   ts:      number;
 }
+
+// ─── Map Types ─────────────────────────────────────────────────
+
+export type ZoneVisibility = "owned" | "scouted" | "dark";
+
+export interface ZoneUnit {
+  id:        string;
+  unitType:  string;
+  quantity:  number;
+  ownerId:   string;
+  status:    string;
+  healthPct: number | null;
+}
+
+export interface Zone {
+  id:                 string;
+  name:               string;
+  sectorId:           string;
+  q:                  number;
+  r:                  number;
+  ownerPlayerId:      string | null;
+  fortificationLevel: number;
+  hasRoad:            boolean;
+  bridgeDestroyed:    boolean;
+  isConnected:        boolean;
+  capturedAt:         string | null;
+  fuelPerHour:        number | null;
+  rationsPerHour:     number | null;
+  steelPerHour:       number | null;
+  creditsPerHour:     number | null;
+  visibility:         ZoneVisibility;
+  units?:             ZoneUnit[];
+}
+
+export interface Sector {
+  id:    string;
+  name:  string;
+  q:     number;
+  r:     number;
+  zones: Omit<Zone, "visibility" | "units">[];
+}
+
+export interface ScoutReport {
+  id:           string;
+  scouterId:    string;
+  targetZoneId: string;
+  reportedAt:   string;
+  unitSnapshot: ZoneUnit[];
+  expiresAt:    string;
+}

--- a/src/routes/map.routes.ts
+++ b/src/routes/map.routes.ts
@@ -99,6 +99,20 @@ export async function mapRoutes(fastify: FastifyInstance) {
     });
   });
 
+  // GET /api/v1/map/scout-reports — active scout reports for the requesting player
+  fastify.get("/map/scout-reports", {
+    preHandler: fastify.authenticate,
+  }, async (req, reply) => {
+    const { playerId } = req.user;
+
+    const reports = await prisma.scoutReport.findMany({
+      where:   { scouterId: playerId, expiresAt: { gt: new Date() } },
+      orderBy: { reportedAt: "desc" },
+    });
+
+    return reply.send({ reports });
+  });
+
   // GET /api/v1/map/signal — all owned zones with their signal chain status
   fastify.get("/map/signal", {
     preHandler: fastify.authenticate,


### PR DESCRIPTION
## Summary

- Replaces the static FOB building grid with a 700-zone interactive PixiJS hex map as the primary game view
- Implements fog-of-war with three visibility states: **owned** (green), **scouted** (blue), **dark** (near-black/enemy-red)
- Pan (drag) and zoom (scroll toward cursor) with label visibility toggled at zoom scale < 0.6
- Clicking the player's FOB zone opens the building panel as a right-side overlay; all other zones open a slide-up zone detail panel
- Zone detail panel lazy-loads live unit positions via `GET /map/zone/:zoneId` and shows resource yields for owned/scouted zones
- Alert feed repositioned as top-right corner overlay, shifting right when building panel is open
- Added `GET /map/scout-reports` backend endpoint and `resolveZoneVisibility()` client-side fog-of-war utility
- WS handler extended to recolor hexes in-place on `ZONE_CAPTURED`, `BATTLE_RESOLVED`, `UNIT_ARRIVED` events

## Test plan

- [ ] Map loads with 700 hexes rendered; player-owned zones appear green, all others dark
- [ ] Pan by dragging, zoom with scroll wheel — no drift or jank
- [ ] Clicking FOB zone: building panel slides in from right AND zone panel appears at bottom
- [ ] Clicking non-FOB zone: only zone panel appears (no building panel)
- [ ] Zone panel shows name, owner, resource yields for owned zones, units for visible zones
- [ ] Dark zones show name + owner label only (no yields/units)
- [ ] Alert feed stays top-right, shifts left when building panel opens
- [ ] `TEST_FAST_BUILD=true` dev workflow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)